### PR TITLE
refactor: synchronize colors across all style files

### DIFF
--- a/src/NTokenizers.Extensions.Spectre.Console/Styles/CSharpStyles.cs
+++ b/src/NTokenizers.Extensions.Spectre.Console/Styles/CSharpStyles.cs
@@ -27,7 +27,7 @@ public sealed class CSharpStyles
     /// <summary>
     /// Gets or sets the style for string literals enclosed in double quotes.
     /// </summary>
-    public Style StringValue { get; set; } = new Style(Color.DarkSlateGray2);
+    public Style StringValue { get; set; } = new Style(Color.DarkSlateGray1);
     
     /// <summary>
     /// Gets or sets the style for single-line and multi-line comments.

--- a/src/NTokenizers.Extensions.Spectre.Console/Styles/CssStyles.cs
+++ b/src/NTokenizers.Extensions.Spectre.Console/Styles/CssStyles.cs
@@ -17,12 +17,12 @@ public sealed class CssStyles
     /// <summary>
     /// Gets or sets the style for CSS rule set start markers ({).
     /// </summary>
-    public Style StartRuleSet { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style StartRuleSet { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for CSS rule set end markers (}).
     /// </summary>
-    public Style EndRuleSet { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style EndRuleSet { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for CSS selectors.
@@ -42,7 +42,7 @@ public sealed class CssStyles
     /// <summary>
     /// Gets or sets the style for CSS string values (quoted strings).
     /// </summary>
-    public Style StringValue { get; set; } = new Style(Color.White);
+    public Style StringValue { get; set; } = new Style(Color.DarkSlateGray1);
 
     /// <summary>
     /// Gets or sets the style for CSS string quotes
@@ -52,7 +52,7 @@ public sealed class CssStyles
     /// <summary>
     /// Gets or sets the style for CSS number values (integer, float).
     /// </summary>
-    public Style Number { get; set; } = new Style(Color.DeepSkyBlue3_1);
+    public Style Number { get; set; } = new Style(Color.Blue);
 
     /// <summary>
     /// Gets or sets the style for CSS units (px, em, %, rem, pt, etc.).
@@ -67,12 +67,12 @@ public sealed class CssStyles
     /// <summary>
     /// Gets or sets the style for opening parentheses in CSS functions.
     /// </summary>
-    public Style OpenParen { get; set; } = new Style(Color.Cyan);
+    public Style OpenParen { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for closing parentheses in CSS functions.
     /// </summary>
-    public Style CloseParen { get; set; } = new Style(Color.Cyan);
+    public Style CloseParen { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for CSS comments.
@@ -82,22 +82,22 @@ public sealed class CssStyles
     /// <summary>
     /// Gets or sets the style for CSS colon separators (:).
     /// </summary>
-    public Style Colon { get; set; } = new Style(Color.DeepSkyBlue4_2);
+    public Style Colon { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for CSS semicolon separators (;).
     /// </summary>
-    public Style Semicolon { get; set; } = new Style(Color.DeepSkyBlue4_2);
+    public Style Semicolon { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for CSS comma separators (,).
     /// </summary>
-    public Style Comma { get; set; } = new Style(Color.DeepSkyBlue4_2);
+    public Style Comma { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for whitespace characters in CSS.
     /// </summary>
-    public Style Whitespace { get; set; } = new Style(Color.Default);
+    public Style Whitespace { get; set; } = new Style(Color.White);
 
     /// <summary>
     /// Gets or sets the style for CSS at-rules (@media, @import, @keyframes, etc.).
@@ -107,7 +107,7 @@ public sealed class CssStyles
     /// <summary>
     /// Gets or sets the style for CSS identifiers (class names, IDs, property names).
     /// </summary>
-    public Style Identifier { get; set; } = new Style(Color.DarkSlateGray1);
+    public Style Identifier { get; set; } = new Style(Color.White);
 
     /// <summary>
     /// Gets or sets the style for CSS operators (+, -, *, /).
@@ -122,12 +122,12 @@ public sealed class CssStyles
     /// <summary>
     /// Gets or sets the style for attribute selector opening brackets ([).
     /// </summary>
-    public Style LeftBracket { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style LeftBracket { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for attribute selector closing brackets (]).
     /// </summary>
-    public Style RightBracket { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style RightBracket { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for CSS equality operators (=).

--- a/src/NTokenizers.Extensions.Spectre.Console/Styles/HtmlStyles.cs
+++ b/src/NTokenizers.Extensions.Spectre.Console/Styles/HtmlStyles.cs
@@ -47,7 +47,7 @@ public sealed class HtmlStyles
     /// <summary>
     /// Gets or sets the style for HTML whitespace characters.
     /// </summary>
-    public Style Whitespace { get; set; } = new Style(Color.Yellow);
+    public Style Whitespace { get; set; } = new Style(Color.White);
     
     /// <summary>
     /// Gets or sets the style for HTML end element tags.
@@ -57,12 +57,12 @@ public sealed class HtmlStyles
     /// <summary>
     /// Gets or sets the style for opening angle brackets (&lt;).
     /// </summary>
-    public Style OpeningAngleBracket { get; set; } = new Style(Color.DeepSkyBlue4_2);
+    public Style OpeningAngleBracket { get; set; } = new Style(Color.Yellow);
     
     /// <summary>
     /// Gets or sets the style for closing angle brackets (&gt;).
     /// </summary>
-    public Style ClosingAngleBracket { get; set; } = new Style(Color.DeepSkyBlue4_2);
+    public Style ClosingAngleBracket { get; set; } = new Style(Color.Yellow);
     
     /// <summary>
     /// Gets or sets the style for HTML attribute names.

--- a/src/NTokenizers.Extensions.Spectre.Console/Styles/JsonStyles.cs
+++ b/src/NTokenizers.Extensions.Spectre.Console/Styles/JsonStyles.cs
@@ -4,7 +4,7 @@ namespace NTokenizers.Extensions.Spectre.Console.Styles;
 
 /// <summary>
 /// Represents the styling configuration for JSON token rendering in Spectre.Console.
-/// This class defines the visual styles for various JSON tokens including objects, arrays, 
+/// This class defines the visual styles for various JSON tokens including objects, arrays,
 /// property names, values, and literals to enable style-rich console syntax highlighting.
 /// </summary>
 public sealed class JsonStyles
@@ -17,22 +17,22 @@ public sealed class JsonStyles
     /// <summary>
     /// Gets or sets the style for the start of an object token.
     /// </summary>
-    public Style StartObject { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style StartObject { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for the end of an object token.
     /// </summary>
-    public Style EndObject { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style EndObject { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for the start of an array token.
     /// </summary>
-    public Style StartArray { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style StartArray { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for the end of an array token.
     /// </summary>
-    public Style EndArray { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style EndArray { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for property names in JSON.
@@ -52,7 +52,7 @@ public sealed class JsonStyles
     /// <summary>
     /// Gets or sets the style for string values in JSON.
     /// </summary>
-    public Style StringValue { get; set; } = new Style(Color.White);
+    public Style StringValue { get; set; } = new Style(Color.DarkSlateGray1);
 
     /// <summary>
     /// Gets or sets the style for numeric values in JSON.

--- a/src/NTokenizers.Extensions.Spectre.Console/Styles/SqlStyles.cs
+++ b/src/NTokenizers.Extensions.Spectre.Console/Styles/SqlStyles.cs
@@ -17,60 +17,60 @@ public sealed class SqlStyles
     /// <summary>
     ///     Gets or sets the style for numeric literals in SQL.
     /// </summary>
-    public Style Number { get; set; } = new Style(Color.DeepSkyBlue3_1);
-    
+    public Style Number { get; set; } = new Style(Color.Blue);
+
     /// <summary>
     ///     Gets or sets the style for string values in SQL.
     /// </summary>
     public Style StringValue { get; set; } = new Style(Color.DarkSlateGray1);
-    
+
     /// <summary>
     ///     Gets or sets the style for comments in SQL.
     /// </summary>
     public Style Comment { get; set; } = new Style(Color.Green);
-    
+
     /// <summary>
     ///     Gets or sets the style for SQL keywords.
     /// </summary>
     public Style Keyword { get; set; } = new Style(Color.Turquoise2);
-    
+
     /// <summary>
     ///     Gets or sets the style for identifiers (table names, column names, etc.) in SQL.
     /// </summary>
     public Style Identifier { get; set; } = new Style(Color.White);
-    
+
     /// <summary>
     ///     Gets or sets the style for operators in SQL.
     /// </summary>
     public Style Operator { get; set; } = new Style(Color.DeepSkyBlue4_2);
-    
+
     /// <summary>
     ///     Gets or sets the style for commas in SQL.
     /// </summary>
-    public Style Comma { get; set; } = new Style(Color.DeepSkyBlue4_2);
-    
+    public Style Comma { get; set; } = new Style(Color.Yellow);
+
     /// <summary>
     ///     Gets or sets the style for dots (periods) in SQL.
     /// </summary>
-    public Style Dot { get; set; } = new Style(Color.DeepSkyBlue4_2);
-    
+    public Style Dot { get; set; } = new Style(Color.Yellow);
+
     /// <summary>
     ///     Gets or sets the style for open parentheses in SQL.
     /// </summary>
-    public Style OpenParenthesis { get; set; } = new Style(Color.DeepSkyBlue4_2);
-    
+    public Style OpenParenthesis { get; set; } = new Style(Color.Yellow);
+
     /// <summary>
     ///     Gets or sets the style for close parentheses in SQL.
     /// </summary>
-    public Style CloseParenthesis { get; set; } = new Style(Color.DeepSkyBlue4_2);
-    
+    public Style CloseParenthesis { get; set; } = new Style(Color.Yellow);
+
     /// <summary>
     ///     Gets or sets the style for sequence terminators in SQL.
     /// </summary>
-    public Style SequenceTerminator { get; set; } = new Style(Color.DeepSkyBlue4_2);
-    
+    public Style SequenceTerminator { get; set; } = new Style(Color.Yellow);
+
     /// <summary>
     ///     Gets or sets the style for undefined or unknown tokens in SQL.
     /// </summary>
-    public Style NotDefined { get; set; } = new Style(Color.DeepSkyBlue4_2);
+    public Style NotDefined { get; set; } = new Style(Color.Yellow);
 }

--- a/src/NTokenizers.Extensions.Spectre.Console/Styles/TomlStyles.cs
+++ b/src/NTokenizers.Extensions.Spectre.Console/Styles/TomlStyles.cs
@@ -4,7 +4,7 @@ namespace NTokenizers.Extensions.Spectre.Console.Styles;
 
 /// <summary>
 /// Represents the styling configuration for TOML token rendering in Spectre.Console.
-/// This class defines the visual styles for various TOML tokens including identifiers, 
+/// This class defines the visual styles for various TOML tokens including identifiers,
 /// strings, numbers, booleans, date-times, and structural elements to enable style-rich console syntax highlighting.
 /// </summary>
 public sealed class TomlStyles
@@ -22,7 +22,7 @@ public sealed class TomlStyles
     /// <summary>
     /// Gets or sets the style for comment tokens.
     /// </summary>
-    public Style Comment { get; set; } = new Style(Color.Gray);
+    public Style Comment { get; set; } = new Style(Color.Green);
 
     /// <summary>
     /// Gets or sets the style for identifier tokens (keys and table names).
@@ -47,37 +47,37 @@ public sealed class TomlStyles
     /// <summary>
     /// Gets or sets the style for open bracket tokens.
     /// </summary>
-    public Style OpenBracket { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style OpenBracket { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for close bracket tokens.
     /// </summary>
-    public Style CloseBracket { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style CloseBracket { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for open brace tokens.
     /// </summary>
-    public Style OpenBrace { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style OpenBrace { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for close brace tokens.
     /// </summary>
-    public Style CloseBrace { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style CloseBrace { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for string quote tokens.
     /// </summary>
-    public Style StringQuote { get; set; } = new Style(Color.White);
+    public Style StringQuote { get; set; } = new Style(Color.DarkSlateGray1);
 
     /// <summary>
     /// Gets or sets the style for string value tokens.
     /// </summary>
-    public Style StringValue { get; set; } = new Style(Color.White);
+    public Style StringValue { get; set; } = new Style(Color.DarkSlateGray1);
 
     /// <summary>
     /// Gets or sets the style for numeric value tokens.
     /// </summary>
-    public Style Number { get; set; } = new Style(Color.DarkSlateGray1);
+    public Style Number { get; set; } = new Style(Color.Blue);
 
     /// <summary>
     /// Gets or sets the style for boolean value tokens.

--- a/src/NTokenizers.Extensions.Spectre.Console/Styles/TypescriptStyles.cs
+++ b/src/NTokenizers.Extensions.Spectre.Console/Styles/TypescriptStyles.cs
@@ -1,5 +1,4 @@
 using Spectre.Console;
-using System.ComponentModel;
 
 namespace NTokenizers.Extensions.Spectre.Console.Styles;
 
@@ -18,12 +17,12 @@ public sealed class TypescriptStyles
     /// <summary>
     ///     Gets or sets the style for open parentheses.
     /// </summary>
-    public Style OpenParenthesis { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style OpenParenthesis { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     ///     Gets or sets the style for close parentheses.
     /// </summary>
-    public Style CloseParenthesis { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style CloseParenthesis { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     ///     Gets or sets the style for commas.
@@ -83,32 +82,32 @@ public sealed class TypescriptStyles
     /// <summary>
     ///     Gets or sets the style for the 'in' keyword.
     /// </summary>
-    public Style In { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style In { get; set; } = new Style(Color.DeepSkyBlue4_2);
 
     /// <summary>
     ///     Gets or sets the style for the 'not in' keyword.
     /// </summary>
-    public Style NotIn { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style NotIn { get; set; } = new Style(Color.DeepSkyBlue4_2);
 
     /// <summary>
     ///     Gets or sets the style for the 'like' keyword.
     /// </summary>
-    public Style Like { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style Like { get; set; } = new Style(Color.DeepSkyBlue4_2);
 
     /// <summary>
     ///     Gets or sets the style for the 'not like' keyword.
     /// </summary>
-    public Style NotLike { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style NotLike { get; set; } = new Style(Color.DeepSkyBlue4_2);
 
     /// <summary>
     ///     Gets or sets the style for the 'limit' keyword.
     /// </summary>
-    public Style Limit { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style Limit { get; set; } = new Style(Color.DeepSkyBlue4_2);
 
     /// <summary>
     ///     Gets or sets the style for the 'match' keyword.
     /// </summary>
-    public Style Match { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style Match { get; set; } = new Style(Color.DeepSkyBlue4_2);
 
     /// <summary>
     ///     Gets or sets the style for sequence terminators.
@@ -123,7 +122,7 @@ public sealed class TypescriptStyles
     /// <summary>
     ///     Gets or sets the style for whitespace.
     /// </summary>
-    public Style Whitespace { get; set; } = new Style(Color.Yellow);
+    public Style Whitespace { get; set; } = new Style(Color.White);
 
     /// <summary>
     ///     Gets or sets the style for date/time values.
@@ -158,7 +157,7 @@ public sealed class TypescriptStyles
     /// <summary>
     ///     Gets or sets the style for the 'between' keyword.
     /// </summary>
-    public Style Between { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style Between { get; set; } = new Style(Color.DeepSkyBlue4_2);
 
     /// <summary>
     ///     Gets or sets the style for undefined values.

--- a/src/NTokenizers.Extensions.Spectre.Console/Styles/XmlStyles.cs
+++ b/src/NTokenizers.Extensions.Spectre.Console/Styles/XmlStyles.cs
@@ -47,7 +47,7 @@ public sealed class XmlStyles
     /// <summary>
     /// Gets or sets the style for XML whitespace characters.
     /// </summary>
-    public Style Whitespace { get; set; } = new Style(Color.Yellow);
+    public Style Whitespace { get; set; } = new Style(Color.White);
     
     /// <summary>
     /// Gets or sets the style for XML end element tags.
@@ -57,12 +57,12 @@ public sealed class XmlStyles
     /// <summary>
     /// Gets or sets the style for opening angle brackets (&lt;).
     /// </summary>
-    public Style OpeningAngleBracket { get; set; } = new Style(Color.DeepSkyBlue4_2);
+    public Style OpeningAngleBracket { get; set; } = new Style(Color.Yellow);
     
     /// <summary>
     /// Gets or sets the style for closing angle brackets (&gt;).
     /// </summary>
-    public Style ClosingAngleBracket { get; set; } = new Style(Color.DeepSkyBlue4_2);
+    public Style ClosingAngleBracket { get; set; } = new Style(Color.Yellow);
     
     /// <summary>
     /// Gets or sets the style for XML attribute names.

--- a/src/NTokenizers.Extensions.Spectre.Console/Styles/YamlStyles.cs
+++ b/src/NTokenizers.Extensions.Spectre.Console/Styles/YamlStyles.cs
@@ -51,7 +51,7 @@ public sealed class YamlStyles
     /// <summary>
     /// Gets or sets the style for colon separators.
     /// </summary>
-    public Style Colon { get; set; } = new Style(Color.DeepSkyBlue3_1);
+    public Style Colon { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for plain values or quoted string values.
@@ -61,12 +61,12 @@ public sealed class YamlStyles
     /// <summary>
     /// Gets or sets the style for quote characters (").
     /// </summary>
-    public Style Quote { get; set; } = new Style(Color.DeepSkyBlue4_2);
+    public Style Quote { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for content between quotes.
     /// </summary>
-    public Style String { get; set; } = new Style(Color.White);
+    public Style String { get; set; } = new Style(Color.DarkSlateGray1);
 
     /// <summary>
     /// Gets or sets the style for anchors.
@@ -86,22 +86,22 @@ public sealed class YamlStyles
     /// <summary>
     /// Gets or sets the style for flow sequence start markers ([).
     /// </summary>
-    public Style FlowSeqStart { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style FlowSeqStart { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for flow sequence end markers (]).
     /// </summary>
-    public Style FlowSeqEnd { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style FlowSeqEnd { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for flow mapping start markers ({).
     /// </summary>
-    public Style FlowMapStart { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style FlowMapStart { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for flow mapping end markers (}).
     /// </summary>
-    public Style FlowMapEnd { get; set; } = new Style(Color.DeepSkyBlue4_1);
+    public Style FlowMapEnd { get; set; } = new Style(Color.Yellow);
 
     /// <summary>
     /// Gets or sets the style for comma separators in flow collections.


### PR DESCRIPTION
Apply consistent color palette across all language style files:
- StringValue: DarkSlateGray1 (was DarkSlateGray2/White)
- Number: Blue (was DeepSkyBlue3_1/DarkSlateGray1)
- Comment: Green (was Gray in TOML)
- Whitespace: White (was Yellow/Default)
- Punctuation (comma, dot, colon, parens, brackets): Yellow (was DeepSkyBlue4_1/2/Cyan)
- Identifier: White (was DarkSlateGray1 in CSS)